### PR TITLE
記事更新とそのテストの実装、Rubocopにより修正

### DIFF
--- a/.github/workflows/wonderful_editor.yml
+++ b/.github/workflows/wonderful_editor.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Setup Ruby 2.7.2
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2
       - name: Setup bundler

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,6 +15,12 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def update
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
     private
 
       def article_params

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -78,3 +78,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 15
+
+RSpec/LetSetup:
+  Enabled: false

--- a/spec/requests/api/articles_spec.rb
+++ b/spec/requests/api/articles_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Articles", type: :request do
+RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
@@ -92,6 +92,36 @@ RSpec.describe "Articles", type: :request do
 
       it "記事作成に失敗する" do
         expect { subject }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "PATCH /articles" do
+    subject { patch(api_v1_article_path(article.id), params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+    before do
+      allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)
+    end
+
+    context "自分が所持している記事のレコードを更新しようとしたとき" do
+      let(:article) { create(:article, user: current_user) }
+
+      it "記事を更新できる" do
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "自分が所持していない記事のレコードを更新しようとしたとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "記事を更新できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
       end
     end
   end


### PR DESCRIPTION
# 概要
 - 記事更新のAPIを実装
 - そのテストを実装
 - Rubocopにより修正
 - actions/setup-ruby@v1 を ruby/setup-ruby@v1 に変更